### PR TITLE
Fix for general mod compatibility

### DIFF
--- a/Contents/mods/BetterSmokerDrops/media/lua/server/items/BSD_Distributions.lua
+++ b/Contents/mods/BetterSmokerDrops/media/lua/server/items/BSD_Distributions.lua
@@ -3,12 +3,25 @@ require 'Items/SuburbsDistributions'
 
 local function BSD_onPreDistributionMerge()
     print("[BSD] removing cigarettes from zombie Distributions")
-    -- remove cigarettes from zombie loot tables
-    local zombInv_female = Distributions[1]["all"]["inventoryfemale"]
-    local zombInv_male = Distributions[1]["all"]["inventorymale"]
+    -- need to identify base distributions: other mods sometimes end up before this in the table,
+    -- and sometimes after, so no hardcoded index is correct
+    local base_dists = nil
+    for k,v in pairs(Distributions) do
+        if v.all and v.all.inventoryfemale and v.all.inventorymale then
+            print("  Base distributions at index " .. k)
+            base_dists = v.all
+        end
+    end
+    if base_dists == nil then
+        print("  Didn't find base distributions")
+    else
+        -- remove cigarettes from zombie loot tables
+        local zombInv_female = base_dists["inventoryfemale"]
+        local zombInv_male = base_dists["inventorymale"]
 
-    RemoveItemFromDistribution(zombInv_female, "Cigarettes")
-    RemoveItemFromDistribution(zombInv_male, "Cigarettes")
+        RemoveItemFromDistribution(zombInv_female, "Cigarettes")
+        RemoveItemFromDistribution(zombInv_male, "Cigarettes")
+    end
 end
 
 -- push changes to Distributions

--- a/Contents/mods/BetterSmokerDrops/media/lua/server/items/BSD_Distributions.lua
+++ b/Contents/mods/BetterSmokerDrops/media/lua/server/items/BSD_Distributions.lua
@@ -5,22 +5,12 @@ local function BSD_onPreDistributionMerge()
     print("[BSD] removing cigarettes from zombie Distributions")
     -- need to identify base distributions: other mods sometimes end up before this in the table,
     -- and sometimes after, so no hardcoded index is correct
-    local base_dists = nil
     for k,v in pairs(Distributions) do
         if v.all and v.all.inventoryfemale and v.all.inventorymale then
-            print("  Base distributions at index " .. k)
-            base_dists = v.all
+            print("  Removing from distribution at index " .. k)
+            RemoveItemFromDistribution(v.all.inventoryfemale, "Cigarettes")
+            RemoveItemFromDistribution(v.all.inventorymale, "Cigarettes")
         end
-    end
-    if base_dists == nil then
-        print("  Didn't find base distributions")
-    else
-        -- remove cigarettes from zombie loot tables
-        local zombInv_female = base_dists["inventoryfemale"]
-        local zombInv_male = base_dists["inventorymale"]
-
-        RemoveItemFromDistribution(zombInv_female, "Cigarettes")
-        RemoveItemFromDistribution(zombInv_male, "Cigarettes")
     end
 end
 


### PR DESCRIPTION
Sometimes badly behaved mods insert themselves in the Distributions table before the base game distributions. Thankfully, the procedural distribution merge code assumes the base game distributions are first, but it doesn't rely on that assumption and so nothing is broken (it works fine by accident).

But to edit base game distributions pre-merge BSD can't rely on the assumption they're at index 1, so it needs to identify them in the Distributions table if any badly behaved mods are present, which is all this does. BSD runs now in the presence of other badly behaved mods, by finding anything that looks like it should merge into the `inventorymale`/`inventoryfemale` entries, and removing cigarettes from them all.

A better approach might be to use a post distribution merge hook (assuming that exists) but I didn't bother looking into that since this works fine and even with quite a lot of mods there's usually only a small number of entries to loop over, so it's not causing any substantial load time increase.